### PR TITLE
Fix small run-time error in transformers

### DIFF
--- a/src/inference.py
+++ b/src/inference.py
@@ -77,9 +77,9 @@ def inference():
             y_mask = y_mask + [0 for _ in range(sequence_len - len(y_mask))]
         attn_mask = [1 if token != TOKEN_IDX[token_style]['PAD'] else 0 for token in x]
 
-        x = torch.tensor(x)
+        x = torch.tensor(x).reshape(1,-1)
         y_mask = torch.tensor(y_mask)
-        attn_mask = torch.tensor(attn_mask)
+        attn_mask = torch.tensor(attn_mask).reshape(1,-1)
         x, attn_mask, y_mask = x.to(device), attn_mask.to(device), y_mask.to(device)
 
         with torch.no_grad():


### PR DESCRIPTION
Using the example training (but with `roberta-base`) and example inference, I ran into:
```

ValueError: Wrong shape for input_ids (shape torch.Size([1, 256])) or attention_mask (shape torch.Size([256]))
```

I could fix this for my setup by adding `.reshape(1,-1)` to `x` and `attentiona_mask`.  